### PR TITLE
Throw inner LoaderException in case of ReflectionTypeLoadException.

### DIFF
--- a/src/NAnt.Core/TypeFactory.cs
+++ b/src/NAnt.Core/TypeFactory.cs
@@ -128,7 +128,20 @@ namespace NAnt.Core {
             ExtensionAssembly extensionAssembly = new ExtensionAssembly (
                 assembly);
 
-            foreach (Type type in assembly.GetTypes()) {
+            Type[] types;
+
+            try {
+                types = assembly.GetTypes();
+            }
+            catch(ReflectionTypeLoadException ex) {
+                if(ex.LoaderExceptions != null && ex.LoaderExceptions.Length > 0) {
+                    throw ex.LoaderExceptions[0];
+                }
+
+                throw;
+            }
+
+            foreach (Type type in types) {
                 //
                 // each extension type is exclusive, meaning a given type 
                 // cannot be both a task and data type


### PR DESCRIPTION
Hi,
When scanning extension assemblies for types `ReflectionTypeLoadException` exception can occur (missing reference for example).
In that case we get message similar to this:
- [loadtasks] Failure scanning "something" for extensions. Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.

My change uses that `LoaderExceptions` property, so the message looks like this:
- [loadtasks] Failure scanning "something" for extensions. Could not load file or assembly 'Interop.MsmMergeTypeLib, Version=2.0.0.0, Culture=neutral,PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.

Let me know, if there's something to change in this commit.

Thanks,
krabicezpapundeklu
