### PR TITLE
Pull request: xmlpoke with failonerror=true does not fail when xpath matches zero nodes

### DIFF
--- a/src/NAnt.Core/Tasks/XmlPokeTask.cs
+++ b/src/NAnt.Core/Tasks/XmlPokeTask.cs
@@ -262,22 +262,21 @@ namespace NAnt.Core.Tasks {
                     + " expression '{0}'.", xpath);
 
                 nodes = document.SelectNodes(xpath, nsMgr);
-
-                // report back how many we found if any. If not then
-                // log a message saying we didn't find any.
-                if (nodes.Count != 0) {
-                    Log(Level.Info, "Found '{0}' nodes matching" 
-                        + " XPath expression '{1}'.", nodes.Count, xpath);
-                } else {
-                    Log(Level.Warning, "No matching nodes were found" 
-                        + " with XPath expression '{0}'.", xpath);
-                }
-                return nodes;
             } catch (Exception ex) {
                 throw new BuildException(string.Format(CultureInfo.InvariantCulture,
                     ResourceUtils.GetString("NA1161"),
                     xpath), Location, ex);
             }
+            // throw exception if no nodes found for XPath (handled gracefully if failonerror=false)
+            if (nodes == null || nodes.Count == 0) {
+                throw new BuildException(string.Format(CultureInfo.InvariantCulture,
+                                                       ResourceUtils.GetString("NA1156"),
+                                                       xpath), Location);
+            }
+            // report back how many we found.
+            Log(Level.Info, "Found '{0}' nodes matching"
+                    + " XPath expression '{1}'.", nodes.Count, xpath);
+            return nodes;
         }
 
         /// <summary>

--- a/tests/NAnt.Core/Tasks/XmlPokeTest.cs
+++ b/tests/NAnt.Core/Tasks/XmlPokeTest.cs
@@ -194,10 +194,15 @@ namespace Tests.NAnt.Core.Tasks {
                 "file=\"{0}\" xpath=\"/configuration/appSettings/add[@key ='server']/@value\"",
                 xmlFile);
 
-            // execute build
-            RunBuild(string.Format(CultureInfo.InvariantCulture, 
-                _projectXml, xmlPokeTaskAttributes, xmlPeekTaskAttributes,
-                "${configuration.server}"));
+            try {
+                // execute build
+                RunBuild(string.Format(CultureInfo.InvariantCulture,
+                    _projectXml, xmlPokeTaskAttributes, xmlPeekTaskAttributes,
+                    "${configuration.server}"));
+            } catch (TestBuildException ex) {
+                // assert that a BuildException was the cause of the TestBuildException
+                Assert.IsTrue((ex.InnerException != null && ex.InnerException.GetType() == typeof(BuildException)));
+            }
         }
 
         [Test]


### PR DESCRIPTION
Replaces previous Pull Request (https://github.com/nant/nant/pull/45) which contained spurious autoformatting changes.
