### PR TITLE
Added successexitcodes to ExternalProgramBase to allow exec task to define alternate exit codes as success.

### DIFF
--- a/src/NAnt.Core/Tasks/ExternalProgramBase.cs
+++ b/src/NAnt.Core/Tasks/ExternalProgramBase.cs
@@ -60,6 +60,7 @@ namespace NAnt.Core.Tasks {
         private ArgumentCollection _arguments = new ArgumentCollection();
         private ManagedExecution _managed = ManagedExecution.Default;
         private string _exeName;
+        private string _successExitCodes = DefaultSuccessExitCodes;
         private int _timeout = Int32.MaxValue;
         private TextWriter _outputWriter;
         private TextWriter _errorWriter;
@@ -78,6 +79,12 @@ namespace NAnt.Core.Tasks {
         /// </summary>
         public const int UnknownExitCode = -1000;
 
+        /// <summary>
+        /// Defines the default success exit code returned by the program. The
+        /// value is zero.
+        /// </summary>
+        public const string DefaultSuccessExitCodes = "0";
+
         #endregion Public Static Fields
 
         #region Private Static Fields
@@ -92,6 +99,22 @@ namespace NAnt.Core.Tasks {
         #endregion Private Static Fields
 
         #region Public Instance Properties
+
+        /// <summary>
+        /// The comma seperated list of valid exit codes from the executed program.
+        /// </summary>
+        /// <value>
+        /// The comma seperated list of valid exit codes.
+        /// </value>
+        /// <remarks>
+        /// Defaults to simply zero.
+        /// </remarks>
+        [TaskAttribute("successexitcodes")]
+        public virtual string SuccessExitCodes
+        {
+            get { return (_successExitCodes != null) ? _successExitCodes : DefaultSuccessExitCodes; }
+            set { _successExitCodes = value; }
+        }
 
         /// <summary>
         /// The name of the executable that should be used to launch the 
@@ -405,7 +428,9 @@ namespace NAnt.Core.Tasks {
 
                 _exitCode = process.ExitCode;
 
-                if (process.ExitCode != 0) {
+                string exitCodeString = _exitCode.ToString();
+                if (string.IsNullOrEmpty(Array.Find<string>(SuccessExitCodes.Split(','), s => string.Compare(s, exitCodeString)==0)))
+                {
                     throw new BuildException(
                         String.Format(CultureInfo.InvariantCulture, 
                         ResourceUtils.GetString("NA1119"), 


### PR DESCRIPTION
The successexitcodes is a comma seperated list of the valid success codes for the exec task.

```
<exec successexitcodes="0,1062" commandline="stop apppool MyApplicationPool" program="c:\windows\system32\inetsrv\appcmd.exe" />
```

The above example allows you to use the appcmd.exe to stop an application pool and the additional exit code 1062 (i.e. application pool is already stopped) is ignored.
