### PR TITLE
Fixed a bug in xmlpoke task causing additional whitespace and newline character when poke empty value into element

### DIFF
--- a/src/NAnt.Core/Tasks/XmlPokeTask.cs
+++ b/src/NAnt.Core/Tasks/XmlPokeTask.cs
@@ -316,7 +316,6 @@ namespace NAnt.Core.Tasks {
                 XmlWriterSettings wSettings = new XmlWriterSettings();
                 wSettings.Indent = true;
                 wSettings.ConformanceLevel = ConformanceLevel.Fragment;
-                wSettings.OmitXmlDeclaration = true;
                 using (XmlWriter output = XmlWriter.Create(fileName, wSettings))
                 {
                     document.WriteTo(output);


### PR DESCRIPTION
Using xmlpoke to clear an element of its value is causing the element to result in whitespace plus a newline character because the XmlDocument's default behavior wraps the closing element on the next line. This causes issues when the xml file is read strictly and the value is then not empty string.

Before fix:

```
<parent>
    <targetElement>
    </targetElement>
</parent>
```

After fix:

```
<parent>
    <targetElement></targetElement>
</parent>
```
