### PR TITLE
Adding function directory::get-name to retrieve folder's name

### DIFF
--- a/src/NAnt.Core/Functions/DirectoryFunctions.cs
+++ b/src/NAnt.Core/Functions/DirectoryFunctions.cs
@@ -218,7 +218,7 @@ namespace NAnt.Core.Functions {
         /// <exception cref="PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length.</exception>
         [Function("get-name")]
         public string GetName(string path) {
-            return new DirectoryInfo(fullname).Name;
+            return new DirectoryInfo(path).Name;
         }
 
         #endregion Public Instance Methods


### PR DESCRIPTION
Adding this function to directory function namespace.

This function returns the directory's name, not the full path.

E.g.

directory::get-name("C:\temp\package\service1")

It returns "service1"
