### PR TITLE
Resolution for Issue #61

### DIFF
--- a/src/NAnt.Core/Tasks/MailTask.cs
+++ b/src/NAnt.Core/Tasks/MailTask.cs
@@ -569,7 +569,10 @@ namespace NAnt.Core.Tasks {
     
                     foreach (string item in parsedAddresses)
                     {
-                        results.Add(ConvertStringToMailAddress(item));
+                        if (!String.IsNullOrEmpty(item))
+                        {
+                            results.Add(ConvertStringToMailAddress(item));
+                        }
                     }
                 }
     

--- a/tests/NAnt.Core/Tasks/MailTaskTest.cs
+++ b/tests/NAnt.Core/Tasks/MailTaskTest.cs
@@ -50,6 +50,21 @@ namespace Tests.NAnt.Core.Tasks
         private static SimpleSmtpServer _smtpServer;
 
         /// <summary>
+        /// A basic NAnt project template to use for new tests for the &lt;mail&gt;
+        /// task that uses the tolist attribute.
+        /// </summary>
+        private const string _xmlToListProjectTemplate = @"
+            <project>
+                <mail
+                    mailhost='localhost'
+                    from='nant@sourceforge.net'
+                    tolist='{0}'
+                    subject='Message from the {1} test method'
+                    mailport='{2}'
+                    message='{3}'/>
+            </project>";
+
+        /// <summary>
         /// The From email address to use for all testing.
         /// </summary>
         private const string _fromEmail = "nant@sourceforge.net";
@@ -352,6 +367,21 @@ namespace Tests.NAnt.Core.Tasks
         #endregion SetUp/TearDown Methods
 
         #region Simple Email Test Methods
+
+        [Test]
+        public void IncludeTrailingSemiColon()
+        {
+            RunBuild(String.Format(_xmlToListProjectTemplate,
+                                   String.Concat(_singleEmail, ";"),
+                                   "IncludeTrailingSemiColon",
+                                   _port,
+                                   CreateSampleEmailMessage("IncludeTrailingSemiColon")
+                                   )
+                     );
+
+            Assert.AreEqual(1, _smtpServer.ReceivedEmailCount);
+            Assert.AreEqual(1, _smtpServer.ReceivedEmail[0].ToAddresses.Length);
+        }
 
         /// <summary>
         /// Test a simple email scenario with 1 email address.


### PR DESCRIPTION
Adjusted the ParseAddress method in the MailTask class to make sure that the current address in a semi-colon separated string is not null or empty before trying to convert it to a MailAddress object.

Tested on:
- Mac OS 10.7 with Mono 2.10.9
  - mono-2.0
  - mono-4.0
- Windows XP
  - net-2.0
  - net-4.0

Thanks,
Ryan
