### PR TITLE
Issue #65 tiny fix.

### DIFF
--- a/src/NAnt.Core/Tasks/GetTask.cs
+++ b/src/NAnt.Core/Tasks/GetTask.cs
@@ -417,6 +417,7 @@ namespace NAnt.Core.Tasks {
                         X509Certificate.CreateFromCertFile(certificate));
                 }
 
+                httpRequest.ReadWriteTimeout = Timeout;
                 webRequest = httpRequest;
             } else {
                 webRequest = WebRequest.Create(uri);


### PR DESCRIPTION
Issue #65, must apply Timeout to HttpWebRequest.ReadWriteTimeout, otherwise
when using the Get task for http/https, the request will timeout after the default
read write timeout of 5 minutes which may be less than the Timeout value
set on the task.
