### PR TITLE
Update App.config to fix "NET1.1 not found"

### DIFF
--- a/src/NAnt.Console/App.config
+++ b/src/NAnt.Console/App.config
@@ -37,8 +37,8 @@
                     version="1.0"
                     description="Microsoft .NET Framework 1.0"
                     sdkdirectory="${path::combine(sdkInstallRoot, 'bin')}"
-                    frameworkdirectory="${path::combine(installRoot, 'v1.0.3705')}"
-                    frameworkassemblydirectory="${path::combine(installRoot, 'v1.0.3705')}"
+                    frameworkdirectory="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.0.3705')}"
+                    frameworkassemblydirectory="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.0.3705')}"
                     clrversion="1.0.3705"
                     clrtype="Desktop"
                     vendor="Microsoft"
@@ -58,7 +58,7 @@
                             </strict>
                         </modes>
                     </runtime>
-                    <reference-assemblies basedir="${path::combine(installRoot, 'v1.0.3705')}">
+                    <reference-assemblies basedir="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.0.3705')}">
                         <include name="Accessibility.dll" />
                         <include name="cscompmgd.dll" />
                         <include name="mscorlib.dll" />
@@ -99,7 +99,7 @@
                     <tool-paths>
                         <directory name="${path::combine(sdkInstallRoot, 'bin')}"
                             if="${property::exists('sdkInstallRoot')}" />
-                        <directory name="${path::combine(installRoot, 'v1.0.3705')}" />
+                        <directory name="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.0.3705')}" />
                     </tool-paths>
                     <project>
                         <readregistry
@@ -139,8 +139,8 @@
                     version="1.1"
                     description="Microsoft .NET Framework 1.1"
                     sdkdirectory="${path::combine(sdkInstallRoot, 'bin')}"
-                    frameworkdirectory="${path::combine(installRoot, 'v1.1.4322')}"
-                    frameworkassemblydirectory="${path::combine(installRoot, 'v1.1.4322')}"
+                    frameworkdirectory="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.1.4322')}"
+                    frameworkassemblydirectory="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.1.4322')}"
                     clrversion="1.1.4322"
                     clrtype="Desktop"
                     vendor="Microsoft"
@@ -160,7 +160,7 @@
                             </strict>
                         </modes>
                     </runtime>
-                    <reference-assemblies basedir="${path::combine(installRoot, 'v1.1.4322')}">
+                    <reference-assemblies basedir="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.1.4322')}">
                         <include name="Accessibility.dll" />
                         <include name="cscompmgd.dll" />
                         <include name="mscorlib.dll" />
@@ -205,7 +205,7 @@
                     <tool-paths>
                         <directory name="${path::combine(sdkInstallRoot, 'bin')}"
                             if="${property::exists('sdkInstallRoot')}" />
-                        <directory name="${path::combine(installRoot, 'v1.1.4322')}" />
+                        <directory name="${path::combine(string::replace(installRoot, 'Framework64', 'Framework'), 'v1.1.4322')}" />
                     </tool-paths>
                     <project>
                         <readregistry 


### PR DESCRIPTION
string::replace(installRoot, 'Framework64', 'Framework')
NET1.1 does not support x64 at all, therefore trying to read it from the registry does not work (if NET2.0 and above only, it would).
I dont know if it handles 100% of the cases, but it seems logical to me.
