### PR TITLE
locatesdk task for 64-bit OS

### DIFF
--- a/src/NAnt.Win32/Tasks/LocateSdkTask.cs
+++ b/src/NAnt.Win32/Tasks/LocateSdkTask.cs
@@ -187,7 +187,7 @@ namespace NAnt.Win32.Tasks {
                         {
                             // Initialize the necessary string array to hold all 
                             // possible directory locations
-                            var installationDir = sdkRegSubKey.OpenSubKey(installedWinSdkVersions[i])
+                            string installationDir = sdkRegSubKey.OpenSubKey(installedWinSdkVersions[i])
                                                               .OpenSubKey(installedWinSdkSubKeys[j])
                                                               .GetValue("InstallationFolder").ToString();
                             string[] netFxDirs = new string[] { installationDir, Path.Combine(installationDir, "bin") };


### PR DESCRIPTION
I tested my change on both 32-bit & 64-bit OS, everything works fine. I believe this change is the minimum to make, with only adding a new RegistryBaseWow64 and extract method to try get SDK path from the WOW64 registry path.
