### PR TITLE
build-nant depends on bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ NANT = $(MONO) bootstrap/NAnt.exe $(NANT_DEBUG)
 
 all: bootstrap build-nant
 
-build-nant: 
+build-nant: bootstrap
 	$(NANT) $(TARGET_FRAMEWORK) -f:NAnt.build build
 
 clean:


### PR DESCRIPTION
Fixes builds when make runs multiple jobs simultaneously (make -j)

When the dependency is not specified. GNU make tries to build _bootstrap_ and _build-nant_ simultanously:

```
juergen@samson:~/tmp/nant → LANG=C make -j2
mkdir -p bootstrap
gmcs  -target:exe -define:MONO,NET_1_0,NET_1_1,NET_2_0,ONLY_2_0 -out:bootstrap/NAnt.exe -r:bootstrap/log4net.dll \
-r:System.Configuration.dll -recurse:src/NAnt.Console/*.cs src/CommonAssemblyInfo.cs
cp -R lib/ bootstrap/lib
# Mono loads log4net before privatebinpath is set-up, so we need this in the same directory
# as NAnt.exe
cp lib/common/neutral/log4net.dll bootstrap
cp src/NAnt.Console/App.config bootstrap/NAnt.exe.config
resgen  src/NAnt.Core/Resources/Strings.resx bootstrap/NAnt.Core.Resources.Strings.resources
Read in 198 resources from '/home/juergen/tmp/nant/src/NAnt.Core/Resources/Strings.resx'
Writing resource file...  Done.
gmcs  -target:library -warn:0 -define:MONO,NET_1_0,NET_1_1,NET_2_0,ONLY_2_0 -out:bootstrap/NAnt.Core.dll -debug \
-resource:bootstrap/NAnt.Core.Resources.Strings.resources -r:lib/common/neutral/log4net.dll \
-r:System.Web.dll -recurse:src/NAnt.Core/*.cs src/CommonAssemblyInfo.cs
src/NAnt.Console/ConsoleStub.cs(415,45): warning CS0618: `System.AppDomain.AppendPrivatePath(string)' is obsolete: `AppDomain.AppendPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead.'
src/NAnt.Console/ConsoleStub.cs(423,49): warning CS0618: `System.AppDomain.AppendPrivatePath(string)' is obsolete: `AppDomain.AppendPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead.'
Compilation succeeded - 2 warning(s)
resgen  src/NAnt.DotNet/Resources/Strings.resx bootstrap/NAnt.DotNet.Resources.Strings.resources
Read in 77 resources from '/home/juergen/tmp/nant/src/NAnt.DotNet/Resources/Strings.resx'
Writing resource file...  Done.
gmcs  -target:library -warn:0 -define:MONO,NET_1_0,NET_1_1,NET_2_0,ONLY_2_0 -out:bootstrap/NAnt.DotNetTasks.dll \
-r:./bootstrap/NAnt.Core.dll -r:bootstrap/lib/common/neutral/NDoc.Core.dll \
-recurse:src/NAnt.DotNet/*.cs -resource:bootstrap/NAnt.DotNet.Resources.Strings.resources \
src/CommonAssemblyInfo.cs
error CS0006: Metadata file `./bootstrap/NAnt.Core.dll' could not be found
Compilation failed: 1 error(s), 0 warnings
Makefile:110: recipe for target 'bootstrap/NAnt.DotNetTasks.dll' failed
make: *** [bootstrap/NAnt.DotNetTasks.dll] Error 1
make: *** Waiting for unfinished jobs....
```
