### PR TITLE
XmlPeek Documentation: default namespace case

### DIFF
--- a/src/NAnt.Core/Tasks/XmlPeekTask.cs
+++ b/src/NAnt.Core/Tasks/XmlPeekTask.cs
@@ -61,6 +61,8 @@ namespace NAnt.Core.Tasks {
     ///   <para>
     ///   The example will read the server value from the above
     ///   configuration file.
+    ///   <para>
+    ///   NOTE: The example below shows that the default namespace needs to also be declared. Simply set any prefix and use that prefix in the xpath.
     ///   </para>
     ///   <code>
     ///     <![CDATA[


### PR DESCRIPTION
Just put a note in the XmlPeek documentation so it is known that for default namespace the namespaces declaration is also required.
