### PR TITLE
Exec timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ test-results/
 *.dat
 *.orig
 *.rej
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ bootstrap/NAnt.Core.dll:
 	$(RESGEN)  src/NAnt.Core/Resources/Strings.resx bootstrap/NAnt.Core.Resources.Strings.resources
 	$(MCS) $(DEBUG) -target:library -warn:0 -define:$(DEFINE) -out:bootstrap/NAnt.Core.dll -debug \
 		-resource:bootstrap/NAnt.Core.Resources.Strings.resources -r:lib${DIRSEP}common${DIRSEP}neutral${DIRSEP}log4net.dll \
-		-r:System.Web.dll -recurse:src${DIRSEP}NAnt.Core${DIRSEP}*.cs src${DIRSEP}CommonAssemblyInfo.cs
+		-r:System.Web.dll -r:System.Configuration.dll -recurse:src${DIRSEP}NAnt.Core${DIRSEP}*.cs src${DIRSEP}CommonAssemblyInfo.cs
 
 bootstrap/NAnt.DotNetTasks.dll:
 	$(RESGEN)  src/NAnt.DotNet/Resources/Strings.resx bootstrap/NAnt.DotNet.Resources.Strings.resources

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# NAnt make makefile for *nix
+# NAnt make makefile for Mono
 MONO=mono
 MCS=gmcs
 RESGEN=resgen
@@ -76,7 +76,12 @@ build-nant: bootstrap
 	$(NANT) $(TARGET_FRAMEWORK) -f:NAnt.build build
 
 clean:
+ifeq ($(OS),Windows_NT)
+	if exist bootstrap rmdir /S /Q bootstrap
+	if exist build rmdir /S /Q build
+else
 	rm -fR build bootstrap
+endif
 
 install: bootstrap
 	$(NANT) $(TARGET_FRAMEWORK) -f:NAnt.build install -D:prefix="$(prefix)" -D:destdir="$(DESTDIR)" -D:doc.prefix="$(docdir)"
@@ -93,12 +98,20 @@ bootstrap: setup bootstrap/NAnt.exe bootstrap/NAnt.Core.dll bootstrap/NAnt.DotNe
 	
 
 setup:
+ifeq ($(OS),Windows_NT)
+	if not exist bootstrap md bootstrap
+	if not exist bootstrap\lib md bootstrap\lib
+	xcopy lib bootstrap\lib /S /Y /Q
+	copy lib\common\neutral\log4net.dll bootstrap
+	copy src\NAnt.Console\App.config bootstrap\NAnt.exe.config
+else
 	mkdir -p bootstrap
 	cp -R lib/ bootstrap/lib
 	# Mono loads log4net before privatebinpath is set-up, so we need this in the same directory
 	# as NAnt.exe
 	cp lib/common/neutral/log4net.dll bootstrap
 	cp src/NAnt.Console/App.config bootstrap/NAnt.exe.config
+endif
 
 bootstrap/NAnt.Core.dll:
 	$(RESGEN)  src/NAnt.Core/Resources/Strings.resx bootstrap/NAnt.Core.Resources.Strings.resources

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -59,7 +59,7 @@ bootstrap\NAnt.exe:
 bootstrap\NAnt.Core.dll:
 	$(RESGEN)  src\NAnt.Core\Resources\Strings.resx bootstrap\NAnt.Core.Resources.Strings.resources
 	$(CSC) $(DEBUG) -target:library -warn:0 -define:$(DEFINE) -out:bootstrap\NAnt.Core.dll -r:bootstrap\log4net.dll \
-		-r:System.Web.dll -r:System.Configuration.dll-resource:bootstrap\NAnt.Core.Resources.Strings.resources \
+		-r:System.Web.dll -r:System.Configuration.dll -resource:bootstrap\NAnt.Core.Resources.Strings.resources \
 		-recurse:src\NAnt.Core\*.cs src\CommonAssemblyInfo.cs
 
 bootstrap\NAnt.DotNetTasks.dll:

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -59,7 +59,7 @@ bootstrap\NAnt.exe:
 bootstrap\NAnt.Core.dll:
 	$(RESGEN)  src\NAnt.Core\Resources\Strings.resx bootstrap\NAnt.Core.Resources.Strings.resources
 	$(CSC) $(DEBUG) -target:library -warn:0 -define:$(DEFINE) -out:bootstrap\NAnt.Core.dll -r:bootstrap\log4net.dll \
-		-r:System.Web.dll -resource:bootstrap\NAnt.Core.Resources.Strings.resources \
+		-r:System.Web.dll -r:System.Configuration.dll-resource:bootstrap\NAnt.Core.Resources.Strings.resources \
 		-recurse:src\NAnt.Core\*.cs src\CommonAssemblyInfo.cs
 
 bootstrap\NAnt.DotNetTasks.dll:

--- a/src/NAnt.Console/App.config
+++ b/src/NAnt.Console/App.config
@@ -14,6 +14,9 @@
         <add key="nant.shadowfiles.cleanup" value="False" />
         <!-- To enable internal log4net logging, uncomment the next line -->
         <!-- <add key="log4net.Internal.Debug" value="true"/> -->
+        <!-- To change the timeout value for external program output, uncomment 
+             the next line and change the value to the desired timeout (in milliseconds) -->
+        <!-- <add key="nant.externalprogram.output.timeout" value="2000"/>-->
     </appSettings>
     <!-- nant config settings -->
     <nant>

--- a/src/NAnt.Core/NAnt.Core.build
+++ b/src/NAnt.Core/NAnt.Core.build
@@ -29,6 +29,7 @@
             <references>
                 <include name="${build.dir}/bin/log4net.dll"/>
                 <include name="System.Web.dll"/>
+                <include name="System.Configuration.dll"/>
             </references>
         </csc>
     </target>

--- a/src/NAnt.Core/NAnt.Core.csproj
+++ b/src/NAnt.Core/NAnt.Core.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
     <Reference Include="log4net">
       <HintPath>..\..\lib\common\neutral\log4net.dll</HintPath>
     </Reference>


### PR DESCRIPTION
This is a simple update that simply allows the user to specify the timeout value for the external program output. The new value defaults to what the value is currently set to. The user can now specify this timeout in the app.config file. This change does not impact any NAnt process as is since the key entry in app.config is commented out and the value is using the old default.

Tested on Win7 net-2.0 & net-4.0.