### PR TITLE
Prevent null value properties

### DIFF
--- a/src/NAnt.Core/PropertyDictionary.cs
+++ b/src/NAnt.Core/PropertyDictionary.cs
@@ -149,7 +149,7 @@ namespace NAnt.Core {
             }
 
             ValidatePropertyName(propertyName, Location.UnknownLocation);
-            ValidatePropertyValue(value, Location.UnknownLocation);
+            ValidatePropertyValue(propertyName, value, Location.UnknownLocation);
             base.OnValidate(key, value);
         }
 
@@ -517,17 +517,28 @@ namespace NAnt.Core {
             }
         }
 
-        private static void ValidatePropertyValue(object value, Location location) {
-            if (value != null) {
-                if (!(value is string)) {
-                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
-                        ResourceUtils.GetString("NA1066"), value.GetType()), 
+        private static void ValidatePropertyValue(string name, object value, Location loc) 
+        {
+            CultureInfo ci = CultureInfo.InvariantCulture;
+
+            try
+            {
+                if (value == null)
+                {
+                    throw new ArgumentException(String.Format(ci,
+                        ResourceUtils.GetString("NA1194"), name));
+                }
+
+                if (!(value is string))
+                {
+                    throw new ArgumentException(String.Format(ci,
+                        ResourceUtils.GetString("NA1066"), value.GetType()),
                         "value");
                 }
-            } else {
-                // TODO: verify this
-                // throw new ArgumentException("Property value '" + propertyName + "' must not be null", "value");
-                return;
+            }
+            catch (Exception x)
+            {
+                throw new BuildException("Property value validation failed: ", loc, x);
             }
         }
 

--- a/src/NAnt.Core/Resources/Strings.resx
+++ b/src/NAnt.Core/Resources/Strings.resx
@@ -277,7 +277,10 @@
     </data>
     <data name="NA1068">
         <value>Read-only property "{0}" cannot be overwritten.</value>
-    </data> 
+    </data>
+    <data name="NA1194">
+        <value>Property value '{0}' must not be null.</value>
+    </data>
     <!-- also a bunch of deprecated property warnings.　--> 
     <!--Messages From: \NAnt.Core/Target.cs-->
     <data name="NA1069">

--- a/src/NAnt.Core/Resources/Strings.resx
+++ b/src/NAnt.Core/Resources/Strings.resx
@@ -279,7 +279,7 @@
         <value>Read-only property "{0}" cannot be overwritten.</value>
     </data>
     <data name="NA1194">
-        <value>Property value '{0}' must not be null.</value>
+        <value>Property '{0}' cannot have null value.</value>
     </data>
     <!-- also a bunch of deprecated property warnings.　--> 
     <!--Messages From: \NAnt.Core/Target.cs-->

--- a/src/NAnt.Core/Tasks/LoopTask.cs
+++ b/src/NAnt.Core/Tasks/LoopTask.cs
@@ -429,9 +429,15 @@ namespace NAnt.Core.Tasks {
                         break;
                 }
             } finally {
-                // Restore all of the old property values
-                for (int nIndex = 0; nIndex < oldPropVals.Length; nIndex++) {
-                    Properties[_props[nIndex]] = oldPropVals[nIndex];
+                // Restore all of the old property values. If any of the old properties
+                // contained a null value, remove that property from the dictionary.
+                string name = null;
+                string val = null;
+                for (int nIndex = 0; nIndex < oldPropVals.Length; nIndex++) 
+                {
+                    name = _props[nIndex];
+                    val = oldPropVals[nIndex];
+                    if (val != null) Properties[name] = val;
                 }
             }
         }

--- a/src/NAnt.Core/Tasks/LoopTask.cs
+++ b/src/NAnt.Core/Tasks/LoopTask.cs
@@ -429,8 +429,9 @@ namespace NAnt.Core.Tasks {
                         break;
                 }
             } finally {
-                // Restore all of the old property values. If any of the old properties
-                // contained a null value, remove that property from the dictionary.
+                // Restore all of the old property values. Make sure that the loop property
+                // (or any other property) is not re-added back into the PropertyDictionary
+                // with a `null` value.
                 string name = null;
                 string val = null;
                 for (int nIndex = 0; nIndex < oldPropVals.Length; nIndex++) 

--- a/tests/NAnt.Core/PropertyDictionaryTest.cs
+++ b/tests/NAnt.Core/PropertyDictionaryTest.cs
@@ -1,0 +1,49 @@
+﻿// NAnt - A .NET build tool
+// Copyright (C) 2001-2015 Gerry Shaw
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+// Ryan Boggs (rmboggs@users.sourceforge.net)
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Xml;
+using NAnt.Core;
+using NUnit.Framework;
+
+namespace Tests.NAnt.Core
+{
+    [TestFixture]
+    public class PropertyDictionaryTest : BuildTestBase
+    {
+        /// <summary>
+        /// Tests to ensure that null values cannot be added to the
+        /// PropertyDictionary.
+        /// </summary>
+        [Test]
+        public void Test_NullPropertyTest()
+        {
+            const string xml = "<project><property name='temp.var' value='some.value'/></project>";
+            Project p = CreateFilebasedProject(xml);
+            PropertyDictionary d = new PropertyDictionary(p);
+            TestDelegate assn = delegate() { d["temp.var"] = null; };
+
+            Assert.Throws<BuildException>(assn,
+                "Null values should not be allowed in PropertyDictionary");
+        }
+    }
+}

--- a/tests/NAnt.Tests.csproj
+++ b/tests/NAnt.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="NAnt.Core\LocationTest.cs" />
     <None Include="NAnt.Core\NAnt.Core.build" />
     <Compile Include="NAnt.Core\ProjectTest.cs" />
+    <Compile Include="NAnt.Core\PropertyDictionaryTest.cs" />
     <Compile Include="NAnt.Core\TargetTest.cs" />
     <Compile Include="NAnt.Core\TaskContainerTest.cs" />
     <Compile Include="NAnt.Core\TaskTest.cs" />


### PR DESCRIPTION
Fix for issue #84

This was tested on Win 7 net-2.0/net-4.0 and Mac OS X mono-2.0/mono-4.0 and also tested by building NAntContrib with no fallout.