### PR TITLE
define EchoTask as mixed to avoid warning message in VS

### DIFF
--- a/doc/releasenotes.html
+++ b/doc/releasenotes.html
@@ -163,6 +163,15 @@
                 </p>
             </div>
         </div>
+        <div style="margin-left: 20px;">
+            <h5><a class="heading" href="help/tasks/echo.html">Echo</a></h5>
+            <div style="margin-left: 20px;">
+                <p>
+                    <code>&lt;echo&gt;Some Important Message&lt;/echo&gt;</code> will not show warning in VS anymore when <code>nant.xsd</code> is used to enable build file support.
+                    (<a href="https://github.com/nant/nant/pull/122">Issue #122</a>)
+                </p>
+            </div>
+        </div>
         <h4>Functions</h4>
         <div style="margin-left: 20px;">
             <h5>

--- a/src/NAnt.Core/Tasks/NAntSchemaTask.cs
+++ b/src/NAnt.Core/Tasks/NAntSchemaTask.cs
@@ -65,7 +65,8 @@ namespace NAnt.Core.Tasks {
         
         // Contains names of tasks that should have the "mixed" attribute for the complex types.
         private static readonly string[] mixedTaskNames = new string[] {
-            "NAnt.Core.Tasks.DescriptionTask"
+            "NAnt.Core.Tasks.DescriptionTask",
+            "NAnt.Core.Tasks.EchoTask",
         };
 
         #endregion Private Static Fields


### PR DESCRIPTION
With `mixed='true'` at EchoTask the warning `The element cannot contain text. Content model is empty.` will disappear when nant.xsd is used to support build file editing.
`<echo>Some Important Message</echo>` will not show warning in VS anymore