### PR TITLE
Use travis-ci for mono on linux CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@
 language: c
 
 install:
-  - sudo apt-get install mono-devel mono-gmcs mono-vbnc
-  
-script: 
+  - curl -sLo /tmp/mono.gpg http://download.mono-project.com/repo/xamarin.gpg
+  - sudo apt-key add /tmp/mono.gpg
+  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq mono-devel mono-gmcs mono-dmcs mono-vbnc nuget libgdiplus=2.10-3
+    
+script:
+    - mono --version
     - make clean run-test TARGET=mono-2.0 
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ install:
   - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
   - sudo apt-get update -qq
   - sudo apt-get install -qq mono-devel mono-gmcs mono-dmcs mono-vbnc nuget libgdiplus=2.10-3
-    
+
+env:
+  - TARGET=mono-2.0 MCS=gmcs
+  - TARGET=mono-4.0 MCS=dmcs
+
 script:
-    - mono --version
-    - make clean run-test TARGET=mono-2.0 
+  - mono --version
+  - make clean run-test TARGET=$TARGET MCS=$MCS
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+
+language: c
+
+script: 
+    - make clean run-test TARGET=mono-2.0 
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ install:
   - sudo apt-key add /tmp/mono.gpg
   - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
   - sudo apt-get update -qq
-  - sudo apt-get install -qq mono-devel mono-gmcs mono-dmcs mono-vbnc nuget libgdiplus=2.10-3
+  - sudo apt-get install -qq mono-devel mono-vbnc nuget libgdiplus=2.10-3
 
 env:
-  - TARGET=mono-2.0 MCS=gmcs
-  - TARGET=mono-4.0 MCS=dmcs
+  - TARGET=mono-2.0 MCS="mcs -sdk:2"
+  - TARGET=mono-4.0 MCS="mcs -sdk:4"
 
 script:
   - mono --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 
 language: c
 
+install:
+  - sudo apt-get install mono-devel mono-gmcs mono-vbnc
+  
 script: 
     - make clean run-test TARGET=mono-2.0 
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ env:
 
 script:
   - mono --version
-  - make clean run-test TARGET=$TARGET MCS=$MCS
+  - make clean run-test TARGET=$TARGET MCS="$MCS"
     


### PR DESCRIPTION
[Travis-ci](https://travis-ci.org) provides a linux based CI build server environment. This could be used to test building nant on mono on linux.