### PR TITLE
Added expectedexitcode attribute

### DIFF
--- a/src/NAnt.Core/Tasks/ExecTask.cs
+++ b/src/NAnt.Core/Tasks/ExecTask.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using NAnt.Core.Attributes;
 using NAnt.Core.Types;
 using NAnt.Core.Util;
@@ -174,6 +175,15 @@ namespace NAnt.Core.Tasks {
             get { return _resultProperty; }
             set { _resultProperty = value; }
         }
+
+        /// <summary>
+        /// Gets or sets the expected exit code.
+        /// </summary>
+        /// <value>
+        /// The expected exit code.
+        /// </value>
+        [TaskAttribute("expectedexitcode")]
+        public int ExpectedExitCode { get; set; }
 
         #endregion Public Instance Properties
 
@@ -340,7 +350,53 @@ namespace NAnt.Core.Tasks {
         /// Executes the external program.
         /// </summary>
         protected override void ExecuteTask() {
-            base.ExecuteTask();
+            try
+            {
+                this.Log(Level.Debug, "Calling ExecuteTask of base class");
+                base.ExecuteTask();
+            }
+            catch (BuildException exception)
+            {
+                this.Log(Level.Debug, "Caught exception: " + exception);
+                const string ExceptionMessage = @"External Program Failed: {0} \(return code was ([\+-]?\d+)\)";
+                string regexPattern = string.Format(ExceptionMessage, Regex.Escape(this.ProgramFileName));
+                Match match = new Regex(regexPattern).Match(exception.Message);
+                if (match.Success && (match.Groups.Count == 2))
+                {
+                  this.Log(Level.Debug, "Exception message matches");
+                  int exitCode;
+                  if (int.TryParse(match.Groups[1].Value, out exitCode))
+                  {
+                    if (exitCode != this.ExpectedExitCode)
+                    {
+                        throw;
+                    }
+                  }
+                  else
+                  {
+                      throw;
+                  }
+                }
+                else
+                {
+                    this.Log(Level.Debug, "Exception message doesn't match");
+                    throw;  
+                }
+            }
+
+            // If the following statement is reached, no exception was thrown by the exec task
+            // Check if the current exit code equals the expected exit code.
+            if (this.ExitCode != this.ExpectedExitCode)
+            {
+                throw new BuildException(
+                                string.Format(
+                                  CultureInfo.InvariantCulture,
+                                  ResourceUtils.GetString("NA1119"),
+                                  ProgramFileName,
+                                  this.ExitCode),
+                                Location);
+            }
+
             if (ResultProperty != null) {
                 Properties[ResultProperty] = base.ExitCode.ToString(
                     CultureInfo.InvariantCulture);


### PR DESCRIPTION
Without the expectedexitcode attribute set, the task behavoir doesn't change. With the expectedexitcode attribute set, the task doesn't report a build error if the executed program doesn't return 0 and the value of expectedexitcode is set to the return code of the program. This is useful for programs which don't return 0 in case of success.