### PR TITLE
Have CatchElement display all exception information.

### DIFF
--- a/doc/releasenotes.html
+++ b/doc/releasenotes.html
@@ -55,10 +55,20 @@
         <h3>Bug Fixes</h3>
         <h4>Tasks</h4>
         <div style="margin-left: 20px;">
+            <h5><a class="heading" href="help/tasks/trycatch.html">TryCatch</a></h5>
+            <div style="margin-left: 20px;">
+                <p>
+                    Make sure that all of the inner exception information is included in the 
+                    <code>catch</code> property.
+                    (Issue <a href="https://github.com/nant/nant/issues/155">#155</a>)
+                </p>
+            </div>
+        </div>
+        <div style="margin-left: 20px;">
             <h5><a class="heading" href="help/tasks/">Tasks</a></h5>
             <div style="margin-left: 20px;">
                 <p>
-                    Make sure that the <c>if</c> and <c>unless</c> attributes are evaluated
+                    Make sure that the <code>if</code> and <code>unless</code> attributes are evaluated
                     before trying to expand properties elsewhere within the task.
                     (Issue <a href="https://github.com/nant/nant/issues/110">#110</a>)
                 </p>

--- a/src/NAnt.Core/Tasks/TryCatchTask.cs
+++ b/src/NAnt.Core/Tasks/TryCatchTask.cs
@@ -355,6 +355,7 @@ namespace NAnt.Core.Tasks {
                     }
                 }
 #endif
+
                 // Get the inner exception information if available.
                 if (e.InnerException != null)
                 {

--- a/src/NAnt.Core/Tasks/TryCatchTask.cs
+++ b/src/NAnt.Core/Tasks/TryCatchTask.cs
@@ -361,7 +361,7 @@ namespace NAnt.Core.Tasks {
                     sb.AppendLine();
                     sb.AppendLine(GetExceptionMessage(e.InnerException));
                 }
-                return sb.ToString();
+                return sb.ToString().Trim();
             }
 
             #endregion

--- a/src/NAnt.Core/Tasks/TryCatchTask.cs
+++ b/src/NAnt.Core/Tasks/TryCatchTask.cs
@@ -19,6 +19,8 @@
 
 using NAnt.Core.Attributes;
 using NAnt.Core.Util;
+using System;
+using System.Text;
 
 namespace NAnt.Core.Tasks {
     /// <summary>
@@ -290,7 +292,7 @@ namespace NAnt.Core.Tasks {
                 if (Property != null) {
                     propertyExists = Project.Properties.Contains(Property);
                     originalPropertyValue = Project.Properties[Property];
-                    Project.Properties[Property] = be.RawMessage;
+                    Project.Properties[Property] = GetExceptionMessage(be);
                 }
 
                 try {
@@ -309,6 +311,60 @@ namespace NAnt.Core.Tasks {
             }
 
             #endregion Public Instance Methods
+
+            #region Private Instance Methods
+
+            /// <summary>
+            /// Parses out the complete exception and inner exception information to be
+            /// consumed by the catch element.
+            /// </summary>
+            /// <param name="e">
+            /// The exception object to get the messages from.
+            /// </param>
+            /// <returns>
+            /// The complete exception message.
+            /// </returns>
+            private string GetExceptionMessage(Exception e)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                // Get the main message from the exception.
+                if (e is BuildException)
+                {
+                    sb.AppendLine(((BuildException)e).RawMessage);
+                }
+                else
+                {
+                    sb.AppendLine(e.Message);
+                }
+
+#if NET_4_0
+                // If e is an aggregated exception, get the messages from
+                // the inner exceptions if they exist.
+                if (e is AggregateException)
+                {
+                    AggregateException agg = e as AggregateException;
+
+                    if (agg.InnerExceptions != null)
+                    {
+                        foreach (Exception inner in agg.InnerExceptions)
+                        {
+                            sb.AppendLine();
+                            sb.AppendLine(GetExceptionMessage(inner));
+                        }
+                    }
+                }
+#endif
+                // Get the inner exception information if available.
+                if (e.InnerException != null)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(GetExceptionMessage(e.InnerException));
+                }
+                return sb.ToString();
+            }
+
+            #endregion
         }
     }
 }


### PR DESCRIPTION
Ensure that the CatchElement in the TryCatch task catch all exception and inner exception information to store in the catch property. Should fix issue #155 .