### PR TITLE
Update MailTask.cs

### DIFF
--- a/src/NAnt.Core/Tasks/MailTask.cs
+++ b/src/NAnt.Core/Tasks/MailTask.cs
@@ -530,7 +530,7 @@ namespace NAnt.Core.Tasks {
         /// The content of the specified file.
         /// </returns>
         private string ReadFile(string filename) {
-            using (StreamReader reader = new StreamReader(File.OpenRead(filename))) 
+            using (StreamReader reader = new StreamReader(filename)) 
             {
                 string result = reader.ReadToEnd();
                 reader.Close();


### PR DESCRIPTION
The FileStream created by File.OpenRead(filename) is never closed. This can caus the unit tests to fail