### PR TITLE
Apply nant-fixmono42_scripttask.patch to fix <script> on mono 4.x 

### DIFF
--- a/src/NAnt.DotNet/Tasks/ScriptTask.cs
+++ b/src/NAnt.DotNet/Tasks/ScriptTask.cs
@@ -394,7 +394,7 @@ namespace NAnt.DotNet.Tasks {
             
             Log(Level.Debug, ResourceUtils.GetString("String_GeneratedCodeLooksLike") + "\n{0}", code);
 
-            CompilerResults results = compiler.CompileAssemblyFromDom(options, compileUnit);
+            CompilerResults results = compiler.CompileAssemblyFromSource(options, code);
 
             Assembly compiled = null;
             if (results.Errors.Count > 0) {


### PR DESCRIPTION
Patch was prepared by @tpokorra [nant-fixmono42_scripttask.patch](https://github.com/tpokorra/lbs-mono-fedora/blob/master/nant/nant-fixmono42_scripttask.patch).
This fix <script> task running on mono 4.x. For more details please see #161