### PR TITLE
Cherry-pick for patch/pull - Microsoft.CSharp.targets namecase

### DIFF
--- a/src/NAnt.Console/NAnt.Console.csproj
+++ b/src/NAnt.Console/NAnt.Console.csproj
@@ -89,7 +89,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\NAnt.Compression\NAnt.Compression.csproj">
       <Project>{8F80C098-94A4-44DB-A25D-C9E455FC3120}</Project>

--- a/src/NAnt.Core/NAnt.Core.csproj
+++ b/src/NAnt.Core/NAnt.Core.csproj
@@ -269,5 +269,5 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Pursuant to building NUnitLite 1.0.0 -- such that might serve to fulfill a build-dependency for some Mono projects e.g mono-tools https://github.com/mono/mono-tools -- I've built NAnt locally, using Mono 6.9.0 on FreeBSD. The build works, with a couple of more-or-less superficial patches. 

Considering as much, I plan on developing a port for NAnt under pkgsrc wip. This port's build configuration would be published to a local contrib. fork of the pkgsrc-wip ports subtree https://github.com/thinkum-sys/pkgsrc-wip principally under https://github.com/thinkum-sys/pkgsrc This project is not endorsed by the NetBSD Foundation. It represents a local fork, with testing -- so far -- in builds under a _locally managed_ pkgsrc distribution, with each of Linux (Debian 10) and FreeBSD 11.2. I've had some success, with building the Mono and the Mono MSBuild fork. I look forward to adding a port for MonoDevelop -- to which, the NAnt port may represent a build dependency by some manner of a dependency graph.

This abbreviated introduction aside, the following changeset modifies the include directive for `Microsoft.CSharp.targets`  in a couple of `*.csproj` files in the NAnt source tree. Under a default Mono installation, the file may not be typically located as Microsoft.CSharp.Targets. Although Mono may support a configuration that would allow for case-folding in file names, that may not comprise the default configuration under some builds.

This patch will probably be included in the wip/nant-mono port. In its pkg build configuration, that port would use the primary NAnt repository, here at GitHub (i.e not my own contrib fork of NAnt, such that may represents mostly a CI/patch repository inasmuch) for general purposes of retrieving the NAnt source code, such as during 'bmake fetch' under the pkgsrc build. 


Log message from original changeset:

Use a lower-case filename type suffix for Microsoft.CSharp.targets

Under recent Mono distibutions, the file Microsoft.CSharp.Targets may
not be available, while the file Microsoft.CSharp.targets would be
available at a similar pathnname.

Mono may support a configuration option for file name case folding. It
may not comprise a defualt configuration, on some hosts.

This changeset updates the filename type suffix for purposes of portability,
in csproj Project XML files that would include Microsoft.CSharp.Targets
when building NAnt.

This changeset also adds an additional line-end symbol, at the end of
each affected file.

Acked-by: Sean Champ <spchamp@users.noreply.github.com>
(cherry picked from commit 1ed6b7922a0144c53005bc99dc8a78cfde3d31a7)