### PR TITLE
Cherry-pick for patch/pull - Add a framework definition, mono-4.5-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # NAnt make makefile for Mono
-MONO=mono
-MCS=gmcs
-RESGEN=resgen
-TARGET=mono-2.0
+MONO?=mono
+MCS?=mcs
+RESGEN?=resgen
+TARGET?=mono-4.5-api
 
 # Contains a list of acceptable targets used to build NAnt
-VALID_TARGETS := mono-2.0 mono-3.5 mono-4.0 mono-4.5 net-2.0 net-3.5 net-4.0 net-4.5
+VALID_TARGETS := mono-2.0 mono-3.5 mono-4.0 mono-4.5 mono-4.5-api net-2.0 net-3.5 net-4.0 net-4.5
 
 ifndef DIRSEP
 ifeq ($(OS),Windows_NT)
@@ -60,6 +60,12 @@ ifeq ($(findstring 4.5,$(SELECTED_TARGET)),4.5)
 DEFINE := $(DEFINE),NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5
 endif
 
+# Similar to mono-4.5 (only available for mono-4.5-api)
+ifeq ($(findstring 4.5,$(SELECTED_TARGET)),4.5-api)
+DEFINE := $(DEFINE),NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5
+endif
+
+
 # If TARGET var is invalid, throw an error
 else
 $(error Specified target "$(TARGET)" is not valid)
@@ -93,14 +99,14 @@ install: bootstrap
 
 run-test: bootstrap
 	$(NANT) $(TARGET_FRAMEWORK) -f:NAnt.build test
-	
+
 bootstrap/NAnt.exe:
 	$(MCS) $(DEBUG) -target:exe -define:$(DEFINE) -out:bootstrap${DIRSEP}NAnt.exe -r:bootstrap${DIRSEP}log4net.dll \
 		-r:System.Configuration.dll -recurse:src${DIRSEP}NAnt.Console${DIRSEP}*.cs src${DIRSEP}CommonAssemblyInfo.cs
 
 
 bootstrap: setup bootstrap/NAnt.exe bootstrap/NAnt.Core.dll bootstrap/NAnt.DotNetTasks.dll bootstrap/NAnt.CompressionTasks.dll ${PLATFORM_REFERENCES}
-	
+
 
 setup:
 ifeq ($(OS),Windows_NT)

--- a/NAnt.build
+++ b/NAnt.build
@@ -819,6 +819,12 @@
         <property name="link.sdkdoc.version" value="SDK_v1_1" />
         <property name="link.sdkdoc.web" value="true" />
     </target>
+    <target name="set-mono-4.5-api-framework-configuration">
+        <property name="nant.settings.currentframework" value="mono-4.5-api" />
+        <property name="current.build.defines" value="${build.defines}MONO,NET_1_0,NET_1_1,NET_2_0,NET_3_5,NET_4_0,NET_4_5,ONLY_4_5" dynamic="true" />
+        <property name="link.sdkdoc.version" value="SDK_v1_1" />
+        <property name="link.sdkdoc.web" value="true" />
+    </target>
 
     <!-- install targets -->
 

--- a/src/NAnt.Console/App.config
+++ b/src/NAnt.Console/App.config
@@ -3099,6 +3099,110 @@
                     </tasks>
                 </framework>
                 <framework
+                    name="mono-4.5-api"
+                    family="mono"
+                    version="4.5"
+                    description="Mono .NET 4.5-api Profile"
+                    sdkdirectory="${toolDirectory}"
+                    frameworkdirectory="${toolDirectory}"
+                    frameworkassemblydirectory="${path::combine(prefix, 'lib/mono/4.5-api')}"
+                    clrversion="4.0.30319"
+                    clrtype="Desktop"
+                    vendor="Mono"
+                    >
+                    <runtime>
+                        <probing-paths>
+                            <directory name="lib/mono/2.0" />
+                            <directory name="lib/mono/neutral" />
+                            <directory name="lib/common/2.0" />
+                            <directory name="lib/common/neutral" />
+                        </probing-paths>
+                        <modes>
+                            <auto>
+                                <engine program="${path::combine(prefix, 'bin/mono')}" />
+                            </auto>
+                            <strict>
+                                <engine program="${path::combine(prefix, 'bin/mono')}">
+                                    <arg value="--runtime=v4.0.30319" />
+                                </engine>
+                            </strict>
+                        </modes>
+                    </runtime>
+                    <reference-assemblies basedir="${path::combine(prefix, 'lib/mono/4.5-api')}">
+                        <include name="*.dll" />
+                    </reference-assemblies>
+                    <task-assemblies>
+                        <!-- include Mono version-neutral assemblies -->
+                        <include name="extensions/mono/neutral/**/*.dll" />
+                        <!-- include Mono 2.0 specific assemblies -->
+                        <include name="extensions/mono/2.0/**/*.dll" />
+                        <!-- include .NET 2.0 specific assemblies -->
+                        <include name="extensions/common/2.0/**/*.dll" />
+                    </task-assemblies>
+                    <tool-paths>
+                        <directory name="${toolDirectory}" />
+                        <directory name="${path::combine(prefix, 'lib/mono/4.5-api')}" />
+                        <!-- unmanaged tools -->
+                        <directory name="${prefix}/bin" />
+                    </tool-paths>
+                    <project>
+                        <if test="${not pkg-config::exists('mono')}">
+                            <fail>Unable to locate 'mono' module using pkg-config. Download the Mono development packages from http://www.mono-project.com/downloads/.</fail>
+                        </if>
+                        <property name="resgen.supportsexternalfilereferences" value="false" />
+                        <property name="prefix" value="${pkg-config::get-variable('mono', 'prefix')}" />
+                        <property name="toolDirectory" value="${path::combine(prefix, 'lib/mono/4.5')}" />
+                        <if test="${not(pkg-config::is-atleast-version('mono', '3.0'))}">
+                            <property name="csc.tool" value="dmcs"/>
+                            <property name="mcs.sdk" value="0"/>
+                        </if>
+                        <if test="${pkg-config::is-atleast-version('mono', '3.0')}">
+                            <property name="csc.tool" value="mcs"/>
+                            <property name="mcs.sdk" value="4.5"/>
+                        </if>
+                    </project>
+                    <tasks>
+                        <task name="al">
+                            <attribute name="managed">true</attribute>
+                        </task>
+                        <task name="csc">
+                            <attribute name="exename">${csc.tool}</attribute>
+                            <attribute name="mcssdk">${mcs.sdk}</attribute>
+                            <attribute name="managed">true</attribute>
+                            <attribute name="langversion">linq</attribute>
+                            <attribute name="supportspackagereferences">true</attribute>
+                            <attribute name="supportsnowarnlist">true</attribute>
+                            <attribute name="supportsdocgeneration">true</attribute>
+                            <attribute name="supportskeycontainer">true</attribute>
+                            <attribute name="supportskeyfile">true</attribute>
+                            <attribute name="supportsdelaysign">true</attribute>
+                            <attribute name="supportslangversion">true</attribute>
+                        </task>
+                        <task name="jsc">
+                            <attribute name="exename">mjs</attribute>
+                            <attribute name="managed">strict</attribute>
+                        </task>
+                        <task name="vbc">
+                            <attribute name="exename">vbnc</attribute>
+                            <attribute name="managed">true</attribute>
+                        </task>
+                        <task name="resgen">
+                            <attribute name="managed">true</attribute>
+                            <attribute name="supportsexternalfilereferences">true</attribute>
+                        </task>
+                        <task name="delay-sign">
+                            <attribute name="exename">sn</attribute>
+                            <attribute name="managed">true</attribute>
+                        </task>
+                        <task name="license">
+                            <attribute name="hascommandlinecompiler">false</attribute>
+                        </task>
+                        <task name="ilasm">
+                            <attribute name="managed">true</attribute>
+                        </task>
+                    </tasks>
+                </framework>
+                <framework
                     name="moonlight-2.0" 
                     family="moonlight" 
                     version="2.0"


### PR DESCRIPTION
Pursuant towards building NAnt -- using Mono -- as (possibly) an indirect build dependency for some projects under mono-tools, subsequently as one possible build dependency for MonoDevelop, I've defined a NAnt framework mono-4.5-api. This framework definition has been tested with a build for NAnt, using Mono 6.9.0 on FreeBSD 11.2.

This patch will probably be included in a port for NAnt under pkgsrc wip, along with the patch now published via Git pull request, in https://github.com/nant/nant/pull/176

Log message from original changeset:
Add a framework definition, mono-4.5-api

The following error may occur when building NAnt with the mono-4.5
target framework specification, under Mono 6.9.0:

~~~~
[build.ext nant]
/usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.DotNet/NAnt.DotNet.build
build
            Buildfile:
            file:///usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.DotNet/NAnt.DotNet.build
            Target framework: Mono 4.5 Profile
            Target(s) specified: build

            build:

            [build csc] Compiling 3 files to
            '/usr/local/src/mono_devo_wk/nant_devsrc/build/mono-4.5.unix/nant-debug/bin/NAnt.exe'.
            [build csc] Compiling 70 files to
            '/usr/local/src/mono_devo_wk/nant_devsrc/build/mono-4.5.unix/nant-debug/bin/NAnt.Core.Tests.dll'.
            [build csc] Compiling 35 files to
            '/usr/local/src/mono_devo_wk/nant_devsrc/build/mono-4.5.unix/nant-debug/bin/NAnt.DotNetTasks.dll'.
                           [resgen] Read in 77 resources from
                           '/usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.DotNet/Resources/Strings.resx'
                           [resgen] Writing resource file...  Done.
            [build csc]
            /usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.Console/ConsoleStub.cs(480,17):
            error CS0433: The imported type `System.Xml.XmlNode' is
            defined multiple times
            [build csc] /usr/pkg/lib/mono/4.5/System.Xml.dll (Location
            of the symbol related to previous error)
            [build csc]
            /usr/pkg/lib/mono/4.5-api/System.Xml.dll (Location of the
            symbol related to previous error)
            [build csc]
            /usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.Console/ConsoleStub.cs(488,17):
            error CS0433: The imported type `System.Xml.XmlElement' is
            defined multiple times
            [build csc] /usr/pkg/lib/mono/4.5/System.Xml.dll (Location
            of the symbol related to previous error)
            [build csc]
            /usr/pkg/lib/mono/4.5-api/System.Xml.dll (Location of the
            symbol related to previous error)
            [build csc]
            /usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.Console/ConsoleStub.cs(504,17):
            error CS0433: The imported type `System.Xml.XmlNodeList' is
            defined multiple times
            [build csc] /usr/pkg/lib/mono/4.5/System.Xml.dll (Location
            of the symbol related to previous error)
            [build csc]
            /usr/pkg/lib/mono/4.5-api/System.Xml.dll (Location of the
            symbol related to previous error)
            [build csc] Compilation failed: 3 error(s), 0 warnings

            BUILD FAILED - 0 non-fatal error(s), 9 warning(s)

            /usr/local/src/mono_devo_wk/nant_devsrc/src/NAnt.Console/NAnt.Console.build(15,10):
            External Program Failed:
            /usr/pkg/lib/mono/4.5/mcs.exe (return code was 1)
~~~~

In order to limit the usage of System.Xml.dll to the object installed
under /usr/pkg/lib/mono/4.5-api/ this changet uses the path 4.5-api
under the NAnt 'reference-assemblies' and 'tool-paths' configuration
directives, within the NAnt framework definition for 4.5-api

This changeset also updates the main Makefile for the additional
framework symbol, mono-4.5-api and sets this as the default TARGET
specification. Moreover, the default MCS is set to 'mcs' in this
changeset.

This changeset reuses the NAnt.build specification for mono-4.5

This changeset has been tested under a build using Mono 6.9.0 x86-64
locally compiled under pkgsrc, on FreeBSD 11.2.

(cherry picked from commit b2af7314384688aa52fe7d86349f4e2debfce862)